### PR TITLE
Stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## Unreleased Changes
 
+## 0.6.0
+
+* Suppress dialogs while rendering directly in AE. Users should no longer need to accept
+  dialogs for overwriting renders or warnings about color bit depth.
+* Fix issue where a Failed task was not propagated to all depedent jobs, causing the
+  dialog to get stuck running, when it should Fail.
+* Fix failure caused by rendering to Google Drive on some fresh installs of ShotGrid.
+  Solved by fixing the following two related issues.
+
+  * Fix path generation ensuring that paths point to the correct output folders.
+  * Fix BNS output module templates. Please remove the existing templates
+
+* Improved reliability of background rendering.
+* Set default background rendering threads to 4.
+
 ## 0.5.0
 
 * Add cancel support. Tasks are now interruptable via the cancel button in the UI.

--- a/python/aequeue/ae.py
+++ b/python/aequeue/ae.py
@@ -319,3 +319,15 @@ class AfterEffectsEngineWrapper(object):
             info['published_file_type'] = 'Rendered Image'
 
         return info
+
+    @contextmanager
+    def suppress_dialogs(self):
+        try:
+            self.adobe.app.beginSuppressDialogs()
+            yield
+        finally:
+            self.adobe.app.endSuppressDialogs(False)
+
+    def render_queue_item(self, rq_item):
+        with self.suppress_dialogs():
+            return self._engine.render_queue_item(rq_item)

--- a/python/aequeue/ae.py
+++ b/python/aequeue/ae.py
@@ -242,17 +242,18 @@ class AfterEffectsEngineWrapper(object):
         self._validate_file_info(data)
         obj = self._to_output_module(obj)
 
-        if sys.platform == 'darwin':
-            full_path = data.get('Full Flat Path')
-            if not full_path:
-                base_path = data.get('Base Path', '')
-                sub_path = data.get('Subfolder Path', '')
-                file_name = data.get('File Name', '')
-                file_template = data.get('File Template', '')
-                full_path = '/'.join([base_path, sub_path, file_name or file_template])
-            self.set_file(obj, full_path)
-        else:
-            obj.setSettings({'Output File Info': data})
+        # Generate full path from provided data.
+        full_path = data.get('Full Flat Path')
+        if not full_path:
+            parts = [
+                data.get('Base Path', ''),
+                data.get('Subfolder Path', ''),
+                data.get('File Name', data.get('File Template', '')),
+            ]
+            full_path = '/'.join([part for part in parts if part])
+
+        # Set output module's file object.
+        self.set_file(obj, full_path.replace('\\', '/'))
 
     def set_file(self, obj, path):
         '''Set the File object for the given RenderQueueItem or OutputModule.
@@ -263,6 +264,11 @@ class AfterEffectsEngineWrapper(object):
         '''
 
         obj = self._to_output_module(obj)
+        # Clear existing file info ensuring we have no conflicting data.
+        obj.setSettings(
+            {'Output File Info': {key: '' for key in self.file_info_properties}}
+        )
+        # Set output module's file object.
         obj.file = self.adobe.File(path)
 
     def get_file_info(self, obj):
@@ -278,8 +284,8 @@ class AfterEffectsEngineWrapper(object):
                 'Subfolder Path': str,  # Subfolder within "Base Path"
                 'File Name': str,  # Name of file
                 'File Template': str,  # Name template like...
-                                       # [compName]/[compName].[fileextension]
-                                       # [compName]/[compName].[#####].[fileextension]
+                                       # [compName]/[compName].[fileExtension]
+                                       # [compName]/[compName].[#####].[fileExtension]
             }
         '''
 

--- a/python/aequeue/app.py
+++ b/python/aequeue/app.py
@@ -413,8 +413,8 @@ class Application(QtCore.QObject):
                 om = rq_item.outputModule(1)
 
                 # Apply output module template
+                om.setSettings({"Output File Info": {"Full Flat Path": "~/[compName]"}})
                 om.applyTemplate(output_module)
-                om.setSettings({'File Name Template': '[compName]'})
 
                 file_info = self.engine.get_file_info(om)
                 path_info = self.engine.get_ae_path_info(file_info['Full Flat Path'])

--- a/python/aequeue/widgets.py
+++ b/python/aequeue/widgets.py
@@ -1098,7 +1098,7 @@ class Options(QtWidgets.QWidget):
         self.bg.stateChanged.connect(self.bg_threads.setEnabled)
         self.bg_threads.setMinimum(1)
         self.bg_threads.setMaximum(cpu_count())
-        self.bg_threads.setValue(int(cpu_count() * 0.5))
+        self.bg_threads.setValue(4)
         self.bg_threads.setSuffix(' Threads')
         self.bg_layout = QtWidgets.QHBoxLayout()
         self.bg_layout.setSpacing(12)
@@ -1452,7 +1452,7 @@ class Window(QtWidgets.QDialog):
             gif=True,
             sg=True,
             bg=False,
-            bg_threads=int(cpu_count() * 0.5),
+            bg_threads=4,
         )
         self.options_header = SectionHeader('OPTIONS')
         self.options_header.right.addWidget(self.status_indicator)


### PR DESCRIPTION
* Suppress dialogs while rendering directly in AE. Users should no longer need to accept
  dialogs for overwriting renders or warnings about color bit depth.
* Fix issue where a Failed task was not propagated to all depedent jobs, causing the
  dialog to get stuck running, when it should Fail.
* Fix failure caused by rendering to Google Drive on some fresh installs of ShotGrid.
  Solved by fixing the following two related issues.

  * Fix path generation ensuring that paths point to the correct output folders.
  * Fix BNS output module templates. Please remove the existing templates

* Improved reliability of background rendering.
* Set default background rendering threads to 4.